### PR TITLE
Fixed method signatures for Dial() to be consistent across all transports

### DIFF
--- a/transports/Dust/Dust.go
+++ b/transports/Dust/Dust.go
@@ -55,19 +55,19 @@ func newDustTransportListener(listener *net.TCPListener, transport *dustServer) 
 }
 
 // Create outgoing transport connection
-func (transport *dustClient) Dial(address string) net.Conn {
+func (transport *dustClient) Dial(address string) (net.Conn, error) {
 	conn, dialErr := net.Dial("tcp", address)
 	if dialErr != nil {
-		return nil
+		return nil, dialErr
 	}
 
 	transportConn, err := Dust.BeginRawStreamClient(conn, transport.serverPubkey)
 	if err != nil {
 		conn.Close()
-		return nil
+		return nil, err
 	}
 
-	return transportConn
+	return transportConn, nil
 }
 
 // Create listener for incoming transport connection

--- a/transports/obfs2/obfs2.go
+++ b/transports/obfs2/obfs2.go
@@ -86,22 +86,22 @@ func (transport *obfs2Transport) NetworkDialer() net.Dialer {
 }
 
 // Create outgoing transport connection
-func (transport *obfs2Transport) Dial(address string) net.Conn {
+func (transport *obfs2Transport) Dial(address string) (net.Conn, error) {
 	// FIXME - should use dialer
 	dialFn := proxy.Direct.Dial
 	conn, dialErr := dialFn("tcp", address)
 	if dialErr != nil {
-		return nil
+		return nil, dialErr
 	}
 
 	dialConn := conn
 	transportConn, err := newObfs2ClientConn(conn)
 	if err != nil {
 		dialConn.Close()
-		return nil
+		return nil, err
 	}
 
-	return transportConn
+	return transportConn, nil
 }
 
 // Create listener for incoming transport connection


### PR DESCRIPTION
Adds error return values to Dial() methods for Dust and obfs2 transports.  This fixes a build breaking issue.  Must be merged together with the corresponding pull request in shapeshifter-dispatcher:

https://github.com/OperatorFoundation/shapeshifter-dispatcher/pull/13

See issue: https://github.com/OperatorFoundation/shapeshifter-transports/issues/3